### PR TITLE
Docs name mismatch fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ To use it:
 dependencies {
     // ...
 
-    // parcelled version
+    // declare memo version
     def memo_version = "1.0.0"
 
     // Memo Library
-    implementation("com.zeoflow:memo:$parcelled_version")
+    implementation("com.zeoflow:memo:$memo_version")
     // Required if you want to use the injector
     implementation("com.zeoflow:memo-annotation:$memo_version")
     annotationProcessor("com.zeoflow:memo-compiler:$memo_version")

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,11 +22,11 @@ To use it:
 dependencies {
     // ...
 
-    // parcelled version
+    // declare memo version
     def memo_version = "1.0.0"
 
     // Memo Library
-    implementation("com.zeoflow:memo:$parcelled_version")
+    implementation("com.zeoflow:memo:$memo_version")
     // Required if you want to use the injector
     implementation("com.zeoflow:memo-annotation:$memo_version")
     annotationProcessor("com.zeoflow:memo-compiler:$memo_version")

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -8,13 +8,13 @@ path: /docs/building-from-source/
 # Building From the Latest Source
 
 If you'll be contributing to the library, or need a version newer than what has
-been released, Parcelled from ZeoFlow can also be built from source.
+been released, Memo from ZeoFlow can also be built from source.
 To do so:
 
 Clone the repository:
 
 ```sh
-git clone https://github.com/zeoflow/parcelled.git
+git clone https://github.com/zeoflow/memo.git
 ```
 
 Then, build the library's AARs using Gradle

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,9 +7,8 @@ path: /docs/contributing/
 
 # General Contributing Guidelines
 
-The Parcelled contributing policies and procedures can be found in the
-main Parcelled documentation repository’s
-[contributing page](https://github.com/zeoflow/parcelled/blob/CONTRIBUTING.md).
+The Memo contributing policies and procedures can be found in the
+main Memo documentation repository’s [contributing page](https://github.com/zeoflow/memo/blob/CONTRIBUTING.md).
 
 To make a contribution, you'll need to be able to build the library from source
 and run our tests.
@@ -19,28 +18,10 @@ and run our tests.
 Take a look at our [instructions](building-from-source.md) on how to build the
 library from source.
 
-## Running Tests
-
-Parcelled for Android has JVM tests as well as Emulator tests.
-
-To run the JVM tests, do:
-
-```sh
-./gradlew test
-```
-
-To run the emulator tests, ensure you have
-[a virtual device set up](https://developer.android.com/studio/run/managing-avds.html)
-and do:
-
-```sh
-./gradlew connectedAndroidTest
-```
-
 ## Code Conventions
 
 Since we all want to spend more time coding and less time fiddling with
-whitespace, Parcelled uses code conventions and styles to
+whitespace, Memo uses code conventions and styles to
 encourage consistency. Code with a consistent style is easier (and less
 error-prone!) to review, maintain, and understand.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,11 +26,11 @@ To use it:
 dependencies {
     // ...
 
-    // parcelled version
+    // declare memo version
     def memo_version = "1.0.0"
 
     // Memo Library
-    implementation("com.zeoflow:memo:$parcelled_version")
+    implementation("com.zeoflow:memo:$memo_version")
     // Required if you want to use the injector
     implementation("com.zeoflow:memo-annotation:$memo_version")
     annotationProcessor("com.zeoflow:memo-compiler:$memo_version")


### PR DESCRIPTION
## Table of Contents
### Link to GitHub issues it solves
closes #18
### Description
Docs name mismatch fix - memo name is not present anywhere

###### [Contributing](https://github.com/zeoflow/memo/blob/master/docs/contributing.md) has more information and tips for a great pull request.