### PR TITLE
Camel low case name entity memo

### DIFF
--- a/demo/src/main/java/com/zeoflow/demo/MainActivity.java
+++ b/demo/src/main/java/com/zeoflow/demo/MainActivity.java
@@ -37,7 +37,7 @@ public class MainActivity extends Activity
 {
 
     /**
-     * UserProfile Component. {@link AppStorage}
+     * userProfile Component. {@link AppStorage}
      */
     @InjectPreference
     public AppStorage_Memo component;
@@ -53,7 +53,7 @@ public class MainActivity extends Activity
 
         initializeUI();
 
-        component.UserProfile().usernameObserver(this, nickname -> initializeUI());
+        component.userProfile().usernameObserver(this, nickname -> initializeUI());
 
 //        memoExample();
     }
@@ -154,7 +154,7 @@ public class MainActivity extends Activity
 
     private void initializeUI()
     {
-        if (!component.UserProfile().getLogin())
+        if (!component.userProfile().getLogin())
         {
             Toast.makeText(zContext, "No user registered. Please register one.", Toast.LENGTH_SHORT).show();
             configureNewActivity(LoginActivity.class)
@@ -173,21 +173,21 @@ public class MainActivity extends Activity
             ViewCompat.setNestedScrollingEnabled(listView, true);
             listView.setAdapter(adapter);
 
-            adapter.addItem(new ItemProfile("Message", component.UserProfile().getUsername()));
-            adapter.addItem(new ItemProfile("Full Name", component.UserProfile().getFullName()));
-            adapter.addItem(new ItemProfile("First Name", component.UserProfile().getUserinfo().getFirstName()));
-            adapter.addItem(new ItemProfile("Last Name", component.UserProfile().getUserinfo().getLastName()));
-            adapter.addItem(new ItemProfile("Views", component.UserProfile().getViews() + ""));
-            adapter.addItem(new ItemProfile("Details", component.UserProfile().getFullNameAndViews()));
-            component.UserProfile().putViews(component.UserProfile().getViews());
+            adapter.addItem(new ItemProfile("Message", component.userProfile().getUsername()));
+            adapter.addItem(new ItemProfile("Full Name", component.userProfile().getFullName()));
+            adapter.addItem(new ItemProfile("First Name", component.userProfile().getUserinfo().getFirstName()));
+            adapter.addItem(new ItemProfile("Last Name", component.userProfile().getUserinfo().getLastName()));
+            adapter.addItem(new ItemProfile("Views", component.userProfile().getViews() + ""));
+            adapter.addItem(new ItemProfile("Details", component.userProfile().getFullNameAndViews()));
+            component.userProfile().putViews(component.userProfile().getViews());
 
-            if (component.Country().getCountryCode() == null)
+            if (component.country().getCountryCode() == null)
             {
-                component.Country().putCountry("Romania");
-                component.Country().putCountryCode("RO");
+                component.country().putCountry("Romania");
+                component.country().putCountryCode("RO");
             }
-            adapter.addItem(new ItemProfile("country", component.Country().getCountry()));
-            adapter.addItem(new ItemProfile("country code", component.Country().getCountryCode()));
+            adapter.addItem(new ItemProfile("country", component.country().getCountry()));
+            adapter.addItem(new ItemProfile("country code", component.country().getCountryCode()));
         }
     }
 

--- a/memo-compiler/src/main/java/com/zeoflow/memo/processor/InjectorGenerator.java
+++ b/memo-compiler/src/main/java/com/zeoflow/memo/processor/InjectorGenerator.java
@@ -80,7 +80,8 @@ public class InjectorGenerator
                         .addParameter(
                                 ParameterSpec.builder(TypeName.get(injectedElement.asType()), INJECT_OBJECT)
                                         .addAnnotation(NonNull.class)
-                                        .build());
+                                        .build()
+                        );
         injectedElement.getEnclosedElements().stream()
                 .filter(variable -> variable instanceof VariableElement)
                 .map(variable -> (VariableElement) variable)
@@ -103,11 +104,12 @@ public class InjectorGenerator
                                 );
                                 if (annotatedClazz.generatedClazzList.contains(annotatedFieldName))
                                 {
+                                    String className = StringUtils.toLowerCamel(annotatedFieldName.replace(PREFERENCE_PREFIX, ""));
                                     builder.addStatement(
                                             INJECT_OBJECT + ".$N = $T.getInstance().$N()",
                                             variable.getSimpleName(),
                                             componentClazz,
-                                            annotatedFieldName.replace(PREFERENCE_PREFIX, "")
+                                            className
                                     );
                                 } else if ((annotatedClazz.clazzName + COMPONENT_PREFIX)
                                         .equals(annotatedFieldName))

--- a/memo-compiler/src/main/java/com/zeoflow/memo/processor/PreferenceComponentGenerator.java
+++ b/memo-compiler/src/main/java/com/zeoflow/memo/processor/PreferenceComponentGenerator.java
@@ -185,7 +185,7 @@ public class PreferenceComponentGenerator
                 {
                     String fieldName = getEntityInstanceFieldName(keyName);
                     MethodSpec instance =
-                            MethodSpec.methodBuilder(StringUtils.toUpperCamel(keyName))
+                            MethodSpec.methodBuilder(StringUtils.toLowerCamel(keyName))
                                     .addModifiers(PUBLIC)
                                     .addStatement("return $N", fieldName)
                                     .returns(getEntityClassType(annotatedEntityMap.get(keyName)))


### PR DESCRIPTION
## Table of Contents
### Link to GitHub issues it solves
closes #23
### Description
The methods that retrieves the entity's name should be camel lower case.
For instance if the class is named `UserProfile` or `userProfile` then the relevant access method will be `userProfile()` for both name.

###### [Contributing](https://github.com/zeoflow/memo/blob/master/docs/contributing.md) has more information and tips for a great pull request.