### PR TITLE
`@KeyName` empty or null than the field will be camel-lowercase

### DIFF
--- a/demo/src/main/java/com/zeoflow/demo/entities/User.java
+++ b/demo/src/main/java/com/zeoflow/demo/entities/User.java
@@ -18,7 +18,7 @@ public class User
     protected final String userNickName = "zeoflow";
 
     /**
-     * key value will be 'Login'. (login's camel uppercase)
+     * key value will be 'login'. (login's camel lowercase)
      */
     @Listener
     protected final boolean login = false;

--- a/memo-compiler/src/main/java/com/zeoflow/memo/processor/PreferenceKeyField.java
+++ b/memo-compiler/src/main/java/com/zeoflow/memo/processor/PreferenceKeyField.java
@@ -63,11 +63,11 @@ public class PreferenceKeyField
         {
             this.keyName =
                     Strings.isNullOrEmpty(annotation_keyName.value())
-                            ? StringUtils.toUpperCamel(this.clazzName)
+                            ? StringUtils.toLowerCamel(this.clazzName)
                             : annotation_keyName.value();
         } else
         {
-            this.keyName = StringUtils.toUpperCamel(this.clazzName);
+            this.keyName = StringUtils.toLowerCamel(this.clazzName);
         }
         if (variableElement.getAnnotation(Observable.class) != null)
         {


### PR DESCRIPTION
## Table of Contents
### Link to GitHub issues it solves
closes #27 
### Description
`@KeyName` empty or null than the field will be camel-lowercase

###### [Contributing](https://github.com/zeoflow/memo/blob/master/docs/contributing.md) has more information and tips for a great pull request.